### PR TITLE
Changed class variables to instance variables in plugins

### DIFF
--- a/lib/memorandom/plugins/aes.rb
+++ b/lib/memorandom/plugins/aes.rb
@@ -2,8 +2,8 @@ module Memorandom
 module Plugins
 class AES < PluginTemplate
 
-  @@description = "This plugin looks for AES encryption keys (128/256)"
-  @@confidence  = 0.50
+  @description = "This plugin looks for AES encryption keys (128/256)"
+  @confidence  = 0.50
 
   #
   # This code is a ruby implementation of AESKeyFind (C) 2008-07-18 Nadia Heninger and Ariel Feldman

--- a/lib/memorandom/plugins/capi.rb
+++ b/lib/memorandom/plugins/capi.rb
@@ -4,8 +4,8 @@ class CAPI < PluginTemplate
 
   require 'openssl'
 
-  @@description = "This plugin looks for Microsoft CryptoAPI encryption keys in memory (PRIVATEBLOB)"
-  @@confidence  = 0.90
+  @description = "This plugin looks for Microsoft CryptoAPI encryption keys in memory (PRIVATEBLOB)"
+  @confidence  = 0.90
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/cc.rb
+++ b/lib/memorandom/plugins/cc.rb
@@ -5,8 +5,8 @@ class CC < PluginTemplate
   # Use the credit_card_validator gem for luhn checks and card verification
   require 'credit_card_validator'
 
-  @@description = "This plugin looks for credit card numbers"
-  @@confidence  = 0.10
+  @description = "This plugin looks for credit card numbers"
+  @confidence  = 0.10
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/der.rb
+++ b/lib/memorandom/plugins/der.rb
@@ -4,8 +4,8 @@ class DER < PluginTemplate
 
   require 'openssl'
 
-  @@description = "This plugin looks for DER-encoded encryption keys (RSA/DSA/EC)"
-  @@confidence  = 0.90
+  @description = "This plugin looks for DER-encoded encryption keys (RSA/DSA/EC)"
+  @confidence  = 0.90
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/hashes.rb
+++ b/lib/memorandom/plugins/hashes.rb
@@ -2,8 +2,8 @@ module Memorandom
 module Plugins
 class Hashes < PluginTemplate
 
-  @@description = "This plugin looks for common hash formats"
-  @@confidence  = 0.10
+  @description = "This plugin looks for common hash formats"
+  @confidence  = 0.10
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/pem.rb
+++ b/lib/memorandom/plugins/pem.rb
@@ -2,8 +2,8 @@ module Memorandom
 module Plugins
 class PEM < PluginTemplate
 
-  @@description = "This plugin looks for PEM-encoded data (keys, certificates, crls, etc)"
-  @@confidence  = 0.90
+  @description = "This plugin looks for PEM-encoded data (keys, certificates, crls, etc)"
+  @confidence  = 0.90
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/rsa.rb
+++ b/lib/memorandom/plugins/rsa.rb
@@ -8,8 +8,8 @@ class RSA < PluginTemplate
 
   require 'openssl'
 
-  @@description = "This plugin looks for RSA keys by finding Bignum-encoded p-values"
-  @@confidence  = 0.90
+  @description = "This plugin looks for RSA keys by finding Bignum-encoded p-values"
+  @confidence  = 0.90
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)

--- a/lib/memorandom/plugins/template.rb
+++ b/lib/memorandom/plugins/template.rb
@@ -1,8 +1,8 @@
 module Memorandom
 class PluginTemplate
 
-  @@description = "This is an unconfigured plugin using the base template"
-  @@confidence  = 0.80
+  @description = "This is an unconfigured plugin using the base template"
+  @confidence  = 0.80
 
   attr_accessor :scanner, :hits
 
@@ -27,11 +27,11 @@ class PluginTemplate
   end
 
   def self.description
-    @@description
+    @description
   end
 
   def self.confidence
-    @@confidence
+    @confidence
   end
 
   def description

--- a/lib/memorandom/plugins/url_params.rb
+++ b/lib/memorandom/plugins/url_params.rb
@@ -2,8 +2,8 @@ module Memorandom
 module Plugins
 class URLParams < PluginTemplate
 
-  @@description = "This plugin looks for interesting URL parameters and POST data"
-  @@confidence  = 0.50
+  @description = "This plugin looks for interesting URL parameters and POST data"
+  @confidence  = 0.50
 
   # Scan takes a buffer and an offset of where this buffer starts in the source
   def scan(buffer, source_offset)


### PR DESCRIPTION
This PR changes the class 'hierarchy' variables `@@description` and `@@confidence` to instance variables within each plugin (and supporting code). Before this change, each time a plugin was required by [plugins.rb](https://github.com/rapid7/memorandom/blob/8630da34a5536ed83b8605f5cee577ab3222631b/lib/memorandom/plugins.rb), the variables were found in the class hierarchy (which looked up to the PluginTemplate class). The value of the variables were then overwritten. This caused the list of plugins to only show the description of the last plugin required (and set the confidence of each plugin to show as 0.10).
